### PR TITLE
push rrtxtrynlqox

### DIFF
--- a/.github/workflows/hcloud-dev.yaml
+++ b/.github/workflows/hcloud-dev.yaml
@@ -20,6 +20,7 @@ jobs:
         github-token: ${{ secrets.GH_TOKEN_HETZNER_RUNNER }}
         hetzner-token: ${{ secrets.HCLOUD_TOKEN }}
         server-location: hel1
+        server-type: cx32
 
   start:
     permissions:
@@ -56,7 +57,7 @@ jobs:
         CLOUD_DISK_PASSWORD: ${{ secrets.CLOUD_DISK_PASSWORD }}
         HCLOUD_DEV_SSH_HOSTKEY: ${{ secrets.HCLOUD_DEV_SSH_HOSTKEY }}
         HCLOUD_DEV_SSH_INITRD_KEY: ${{ secrets.HCLOUD_DEV_SSH_INITRD_KEY }}
-        TF_VAR_server_type: CX42
+        TF_VAR_server_type: CX22
       run: |
         nix shell nixpkgs#jq nixpkgs#bashInteractive --command bash <<NIXSH
         TF_VAR_kexec_tarball="$(nix build .#kexec-installer-nixos-unstable-noninteractive --print-out-paths --no-link)/nixos-kexec-installer-noninteractive-x86_64-linux.tar.gz"


### PR DESCRIPTION
- **chore: flake - remove non-existant followed inputs**
- **chore/fix: use CX22 hcloud server for github runner**
