### PR TITLE
fix: darwin nix for new install procedure

### DIFF
--- a/darwin/aarch64-darwin/VW2WRF4694.nix
+++ b/darwin/aarch64-darwin/VW2WRF4694.nix
@@ -20,8 +20,6 @@
     ../../profiles/home-manager.nix
   ];
 
-  services.nix-daemon.enable = true;
-
   homebrew.enable = true;
   homebrew.taps = [
     {
@@ -44,7 +42,7 @@
 
   #services.karabiner-elements.enable = true; ## doesn't work atm
   system.defaults.dock.autohide = true;
-  security.pam.enableSudoTouchIdAuth = true;
+  security.pam.services.sudo_local.touchIdAuth = true;
   system.defaults.trackpad.Clicking = true;
   system.defaults.NSGlobalDomain.AppleInterfaceStyle = "Dark";
   system.defaults.NSGlobalDomain."com.apple.trackpad.scaling" = 3.0;
@@ -68,24 +66,7 @@
     window_gap = 10;
   };
 
-  nix = {
-    settings.trusted-users = ["root" adminUser.name];
-    extraOptions = ''
-      experimental-features = nix-command flakes
-      keep-outputs = true
-      keep-derivations = true
-      tarball-ttl = 900
-    '';
-    gc = {
-      automatic = true;
-      interval = {
-        Weekday = 0;
-        Hour = 0;
-        Minute = 0;
-      };
-      options = "--delete-older-than 30d";
-    };
-  };
+  nix.enable = false;
 
   users = {
     users.${adminUser.name} = {

--- a/darwin/aarch64-darwin/mini.nix
+++ b/darwin/aarch64-darwin/mini.nix
@@ -104,23 +104,7 @@
     };
   };
 
-  nix = {
-    extraOptions = ''
-      experimental-features = nix-command flakes
-      keep-outputs = true
-      keep-derivations = true
-      tarball-ttl = 900
-    '';
-    gc = {
-      automatic = true;
-      interval = {
-        Weekday = 0;
-        Hour = 0;
-        Minute = 0;
-      };
-      options = "--delete-older-than 30d";
-    };
-  };
+  nix.enable = false;
 
   users = {
     users.${adminUser.name} = {

--- a/hosts/x86_64-linux/cygnus.nix
+++ b/hosts/x86_64-linux/cygnus.nix
@@ -2,7 +2,6 @@
   adminUser,
   hostName,
   config,
-  pkgs,
   ...
 }: {
   publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHJycc3NgaX+coWkJIQEmHS3HBF99o3SkZ7sIm83eiiW";

--- a/hosts/x86_64-linux/icarus.nix
+++ b/hosts/x86_64-linux/icarus.nix
@@ -3,8 +3,6 @@
   config,
   hostName,
   pkgs,
-  lib,
-  tailnet,
   ...
 }: {
   publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHaa82NwBC+ty4Wyeuf5kdava7huSYF6k0NYF2ahwayW";


### PR DESCRIPTION
Also remove unused parameters from icarus.nix and cygnus.nix hosts.