### PR TITLE
fix(lsd/mac): aliases are on by default now

### DIFF
--- a/users/profiles/mac.nix
+++ b/users/profiles/mac.nix
@@ -65,7 +65,6 @@ in {
 
   programs.lsd = {
     enable = true;
-    enableAliases = true;
   };
 
   programs.direnv = {


### PR DESCRIPTION
the general setting is deprecated