### PR TITLE
fix: update tuwunel flake to latest valid commit

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2497,11 +2497,11 @@
         "rocksdb": "rocksdb"
       },
       "locked": {
-        "lastModified": 1754937928,
-        "narHash": "sha256-Ib7nmK019dL1ar0la76MykgeZVFVlqZVMnJ9X504Kn4=",
+        "lastModified": 1758661357,
+        "narHash": "sha256-LUUWsxwCM+xLXAM6wRigmZLnXp7pHYygRiYf9fQ0BtU=",
         "owner": "matrix-construct",
         "repo": "tuwunel",
-        "rev": "628597c3188f0fa279feecddf14b8859be28cc5c",
+        "rev": "c3bc8c14f7940deda4a20fd88509aacfa9017401",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The previous commit (628597c3188f0fa279feecddf14b8859be28cc5c) no longer exists in the tuwunel repository. Updated to the latest valid commit c3bc8c14f7940deda4a20fd88509aacfa9017401.

Fixes #1539

🤖 Generated with [Claude Code](https://claude.ai/code)