### PR TITLE
feat(vega): auto-grow root partition, reduce image size

### DIFF
--- a/flake/kubevirt-images.nix
+++ b/flake/kubevirt-images.nix
@@ -18,7 +18,7 @@
             format = "qcow2";
             partitionTableType = "legacy+gpt";
             diskSize = "auto";
-            additionalSpace = "4096M";
+            additionalSpace = "1024M";
             memSize = 2048;
           };
           containerDisk = pkgs.dockerTools.buildImage {

--- a/profiles/kubevirt.nix
+++ b/profiles/kubevirt.nix
@@ -29,9 +29,12 @@
   ];
   boot.kernelModules = ["virtio_balloon" "virtio_console" "virtio_rng"];
 
+  boot.growPartition = true;
+
   fileSystems."/" = {
     device = "/dev/vda2";
     fsType = "ext4";
+    autoResize = true;
   };
 
   fileSystems."/home" = {


### PR DESCRIPTION
- Add boot.growPartition + autoResize so root expands to fill PVC
- Reduce additionalSpace from 4096M to 1024M (grows at boot anyway)
- Root partition now uses full 64Gi PVC instead of being stuck at ~11G