### PR TITLE
fix(jupiter): set jovian.steam.desktopSession to gamescope-wayland

### DIFF
--- a/configurations/nixos/x86_64-linux/jupiter.nix
+++ b/configurations/nixos/x86_64-linux/jupiter.nix
@@ -14,6 +14,7 @@
   jovian.steam.enable = true;
   jovian.steam.autoStart = true;
   jovian.steam.user = adminUser.name;
+  jovian.steam.desktopSession = "gamescope-wayland";
   jovian.hardware.has.amd.gpu = true;
 
   ephemeralRoot = true;


### PR DESCRIPTION
## Summary
- `world upgrade` on jupiter fails to evaluate because `jovian.steam.desktopSession` is null while `autoStart = true`. The jovian autostart module interpolates `${cfg.desktopSession}` into a systemd `ExecStart` string, triggering `cannot coerce null to a string`.
- Set it to `"gamescope-wayland"` to keep current behavior (matches the in-tree warning's recommendation).

## Test plan
- [x] `nix eval .#nixosConfigurations.jupiter.config.system.build.toplevel.drvPath` succeeds locally
- [ ] `world upgrade` on jupiter once merged