### PR TITLE
feat(jupiter): enable sunshine streaming

### DIFF
--- a/configurations/nixos/x86_64-linux/jupiter.nix
+++ b/configurations/nixos/x86_64-linux/jupiter.nix
@@ -17,6 +17,13 @@
   jovian.steam.desktopSession = "gamescope-wayland";
   jovian.hardware.has.amd.gpu = true;
 
+  services.sunshine = {
+    enable = true;
+    autoStart = true;
+    capSysAdmin = false;
+    openFirewall = true;
+  };
+
   ephemeralRoot = true;
   imports = [
     ../../../profiles/admin-user/home-manager.nix
@@ -33,7 +40,10 @@
 
   disko.devices.disk.disk1.device = "/dev/nvme0n1";
 
-  users.users.${adminUser.name}.linger = true; ## start user systemd units on boot
+  users.users.${adminUser.name} = {
+    linger = true; ## start user systemd units on boot
+    extraGroups = ["render" "video" "uinput"];
+  };
 
   system.autoUpgrade = {
     enable = true;


### PR DESCRIPTION
## Summary
- Enable sunshine on jupiter mirroring the neptune setup (`enable`, `autoStart`, `capSysAdmin = false`, `openFirewall`).
- Add `render`/`video`/`uinput` to the admin user's `extraGroups` (sunshine needs `uinput` for input injection).

## Test plan
- [x] `nix eval .#nixosConfigurations.jupiter.config.system.build.toplevel.drvPath` succeeds locally
- [ ] After merge: confirm `sunshine.service` is active on jupiter and the web UI on port 47990 is reachable over tailscale