### PR TITLE
chore(claude): move universal tone/formatting rules to base.md

### DIFF
--- a/users/profiles/claude/base.md
+++ b/users/profiles/claude/base.md
@@ -4,6 +4,23 @@
 - No preamble/postamble ("Here's what I'll do...").
 - Batch tool calls and run commands in parallel when possible.
 
+## Tone
+
+- Conversational - like talking to a colleague, not writing a textbook
+- Direct - get to the point, no throat-clearing
+- Honest - don't oversell, say what it does
+- No emdashes (use normal -), no marketing buzzwords, no "revolutionary"
+- Never use "load-bearing" or "load bearing"
+
+## Formatting
+
+- **Bold**: sparingly, for genuine emphasis only. Never bold every other word.
+- **Italics**: avoid entirely - hard to read, rarely adds value. Use `code` for
+  technical terms and bold for emphasis instead.
+- **Emojis**: fine in moderation (section headings). Never in code examples or
+  as bullet substitutes.
+- **Code blocks**: always specify the language.
+
 ## Code Comments
 
 Comments are good when they add value. Do NOT add comments on obvious code - that

--- a/users/profiles/claude/rules/writing.md
+++ b/users/profiles/claude/rules/writing.md
@@ -1,21 +1,11 @@
 These rules apply to all written content: READMEs, docs, walkthroughs, blog posts.
 
-## Tone
-
-- Conversational - like talking to a colleague, not writing a textbook
-- Direct - get to the point, no throat-clearing
-- Honest - don't oversell, say what it does
-- No emdashes (use normal -), no marketing buzzwords, no "revolutionary"
+General tone and formatting rules live in `base.md` and apply universally; this
+file covers prose-specific concerns.
 
 ## Formatting
 
-- **Bold**: sparingly, for genuine emphasis only. Never bold every other word.
-- **Italics**: avoid entirely - hard to read, rarely adds value. Use `code` for
-  technical terms and bold for emphasis instead.
-- **Emojis**: fine in moderation (section headings). Never in code examples or
-  as bullet substitutes.
 - **Line length**: 80-100 chars (except URLs and code blocks).
-- **Code blocks**: always specify the language.
 
 ## READMEs
 


### PR DESCRIPTION
## Summary
- Move tone (conversational/direct/honest/no-emdashes) and formatting (bold/italics/emojis/code-block language) rules from `users/profiles/claude/rules/writing.md` into `users/profiles/claude/base.md` so they apply to all output, not just doc-writing contexts
- Add restriction against the term "load-bearing"
- `writing.md` now keeps only prose-specific concerns (line length, READMEs, structure priority)

## Test plan
- [x] No code changes; rules-only refactor